### PR TITLE
Fix PS Vita hash checking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.0.1
-          release_name: v2.0.1
+          tag_name: v2.0.2
+          release_name: v2.0.2
           body: |
-            Fixes games.yml parsing.
+            Fixes hash checking for PS Vita updates.
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/PySN.py
+++ b/PySN.py
@@ -410,11 +410,11 @@ class App(customtkinter.CTk):
                 self.textbox.open_button_list[index].configure(state='disabled')
                 self.textbox.status_list[index].configure(text_color = 'yellow', text='Checking Hash...')
                 with open(fileloc,'rb') as f:
-                    if console == 'PlayStation 3':
+                    if console == 'PlayStation 3' or console == "PlayStation Vita":
                         data = f.read()[:-32]
                     else: data = f.read()
                     sha1.update(data)
-                if hash == (sha1.hexdigest()):
+                if hash.upper() == (sha1.hexdigest().upper()):
                     self.textbox.status_list[index].configure(text_color = 'green', text='Download Complete!')
                 else:
                     self.textbox.status_list[index].configure(text_color = 'red', text='HASH MISMATCH DETECTED!')

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ You can also point PySN to your RPCS3 installation via the settings. If you do s
 Known Bugs
 ============
 Keep your eye on the Issues page for anything not listed here.
-- PS Vita updates will trigger a hash mismatch error.
 - Sometimes the Download All button just doesn't download all of the updates. Not sure why, as it should iterate through all of the buttons in the array. Just double check that it didn't miss anything if you use this feature.
 - If you manage to keep a partially downloaded file (i.e. by closing PySN in the middle of a download), it will show up as "already owned" when you search for it again. I just need to run a hash or size check when the search runs to fix this.
 


### PR DESCRIPTION
Fixes hash checking error for PS Vita updates by handling the hash the same as PS3 games.