### PR TITLE
Strip game name of leading and trailing spaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.0.2
-          release_name: v2.0.2
+          tag_name: v2.0.3
+          release_name: v2.0.3
           body: |
-            Fixes hash checking for PS Vita updates.
+            Strips game name of leading or trailing spaces to avoid errors when making directories and placing files in them.
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/PySN.py
+++ b/PySN.py
@@ -337,7 +337,7 @@ class App(customtkinter.CTk):
                     sha1 = (item.get('sha1sum'))
                     update_size = int((item.get('size')))
 
-                name = game_name.replace(':', ' -').replace('/', ' ').replace('?', '')
+                name = game_name.replace(':', ' -').replace('/', ' ').replace('?', '').strip()
                 download_path = save_dir + console + '/' + title_id + ' ' + name
                 update_file = path.basename(url)      
                 self.textbox.add_item(game_name, title_id, ' v' + ver, url, console, update_size, sha1, index, download_path, update_file)


### PR DESCRIPTION
Strip the game name of leading and trailing spaces to avoid issues when making directories and placing files in them.

Fixes issue #13.