### PR TITLE
Fix games.yml parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.0.7
-          release_name: v2.0.7
+          tag_name: v2.0.8
+          release_name: v2.0.8
           body: |
-            Add lots of comments. Some cleanup.
+            Fix indices getting messed up when scraping games.yml.
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/PySN.py
+++ b/PySN.py
@@ -410,12 +410,7 @@ class App(customtkinter.CTk):
                     is_shit_there(self, download_path, index_list[i], update_file)
                     i = i+1
             else: return
-        elif game_name == 'Invalid ID':
-            self.textbox.clear_items()
-            self.textbox.add_item('Invalid ID: ' + title_id, '', '', '', '', 0, '', '', '', '')
-        else:
-            self.textbox.clear_items() 
-            self.textbox.add_item('No updates available for ' + title_id, '', '', '', '', 0, '', '', '', '')
+        else: return
     
     #Pauses and resumes download and sends pause message to the queue.
     def toggle_pause(self, index):


### PR DESCRIPTION
Games.yml scraping got messed up with #21. PySN would not show if a title had no updates, and indexes would get messed up. This caused some odd download button behavior.

This PR removes a bit of code to fix messed up indices and to show if a title has no updates.