### PR TITLE
Better handling for fw searches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.1.1
-          release_name: v2.1.1
+          tag_name: v2.1.2
+          release_name: v2.1.2
           body: |
-            Minor cleanup.
+            Add more robust handling for firmware searches.
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/PySN.py
+++ b/PySN.py
@@ -208,7 +208,7 @@ class ScrollableLabelButtonFrame(customtkinter.CTkScrollableFrame):
     def add_item(self, name, title_id, ver, url, console, update_size, sha1, index, download_path, fileloc):
 
         #Truncates the name depending on it's length. Assigns the title id, version, and name to a label on the left side of the frame.
-        if len(title_id) == 2:  
+        if len(title_id) == 2 and sha1 == 'N/A':
             title_label = customtkinter.CTkLabel(self, text= title_id + ver + ' - ' + name, anchor='w')
         elif ver.startswith(' D') and len(name)>9 and not name.startswith('Invalid ID') and not name.startswith('No updates available for') and name != 'No updates found':  
             title_label = customtkinter.CTkLabel(self, text= title_id + ver + ' - ' + name[:9] + '...', anchor='w')


### PR DESCRIPTION
Everything seemed to work just fine, but I feel better about having this bit of code when adding widgets.

Helps distinguish between searches for firmware and searches for other 2-digit values (even though you wouldn't ever search for those 2-digit values, and the current handling for this seems to work fine).