### PR TITLE
Make console combobox read-only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.1.2
-          release_name: v2.1.2
+          tag_name: v2.1.3
+          release_name: v2.1.3
           body: |
-            Add more robust handling for firmware searches.
+            Make console dropdown menu read-only.
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/PySN.py
+++ b/PySN.py
@@ -288,6 +288,7 @@ class App(customtkinter.CTk):
         self.entry.grid(row=0, column=0, padx=(4,2), pady=(6,0), sticky='ew')
         self.combobox = customtkinter.CTkComboBox(master=self, values=['PlayStation 3', 'PlayStation 4', 'PlayStation Vita'], width = 125)
         self.combobox.grid(row=0, column=1, columnspan=1, padx=(2,2), pady=(6,0), sticky='ew')
+        self.combobox.configure(state = 'readonly')
         self.checkbox = customtkinter.CTkCheckBox(master=self, text='Search Games.yml')
         self.checkbox.grid(row=0, column=2, columnspan=2, padx=(2,4), pady=(6,0), sticky='w')
         self.button1 = customtkinter.CTkButton(master=self, command=self.button_search, text='Search', width = 125)


### PR DESCRIPTION
Disables user-input in the "console" combobox. Previously any values outside of "PlayStation 4" or "PlayStation Vita" would default to a search for PS3 title updates.

Do this after populating the widget so that the default text isn't garbage collected, which would leave us with a blank combobox value by default.