### PR TITLE
Get path on Unix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,10 +103,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.1.8
-          release_name: Release v2.1.8
+          tag_name: v2.1.9
+          release_name: v2.1.9
           body: |
-            Build MacOS Executable.
+            Correctly get the path to PySN on unix systems.
+            
+            This fixes updates not saving in the correct default locations on MacOS and Linux.
           draft: false
           prerelease: false
 

--- a/PySN.py
+++ b/PySN.py
@@ -72,7 +72,7 @@ class ConfigSettings():
 
     #Checks for the config file, and gets the settings from it. Saves default config if none present.
     def check_config():
-        normalized_path = os.getcwd().replace('\\','/')
+        normalized_path = os.path.dirname(__file__).replace('\\','/')
         config_path = (normalized_path + '/config.ini')
         if path.exists(config_path):
             save_dir, rpcs3_dir = ConfigSettings.get_config()


### PR DESCRIPTION
Ditch getcwd() in favor of path.dirname() to correctly get the path to PySN on Unix systems. This fixes updates not saving in the correct default locations on MacOS and Linux.