### PR TITLE
Fix config error and paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,12 +103,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.1.9
-          release_name: v2.1.9
+          tag_name: v2.1.10
+          release_name: v2.1.10
           body: |
-            Correctly get the path to PySN on unix systems.
-            
-            This fixes updates not saving in the correct default locations on MacOS and Linux.
+            Fix config file error and actually get the correct path to PySN on Unix systems.
+
+            (Previous version crashes)
           draft: false
           prerelease: false
 

--- a/PySN.py
+++ b/PySN.py
@@ -8,6 +8,7 @@ import os
 import queue
 import yaml
 import time
+import sys
 from fnmatch import fnmatch
 from configparser import ConfigParser
 import xml.etree.ElementTree as ET
@@ -53,6 +54,14 @@ class ConfigSettings():
     def __init__(self):
         super().__init__()
 
+    def get_path():
+        if getattr(sys, 'frozen', False):
+            app_path = os.path.dirname(sys.executable)
+        else:
+            app_path = os.path.dirname(os.path.abspath(__file__))
+        normalized_path = app_path.replace('\\','/')
+        return normalized_path
+
     #Gets settings from the config file.
     def get_config():
         config = ConfigParser()
@@ -72,9 +81,8 @@ class ConfigSettings():
 
     #Checks for the config file, and gets the settings from it. Saves default config if none present.
     def check_config():
-        normalized_path = os.path.dirname(__file__).replace('\\','/')
-        config_path = (normalized_path + '/config.ini')
-        if path.exists(config_path):
+        normalized_path = ConfigSettings.get_path()
+        if os.path.exists('config.ini'):
             save_dir, rpcs3_dir = ConfigSettings.get_config()
         else:
             save_dir = (normalized_path + '/Updates/')


### PR DESCRIPTION
Fixes the config error from the last PR/Release, which would cause a blank settings screen and crashes on subsequent boots.

Also fixes paths still not being correct on Unix systems when the app is frozen and distributed as an executable.