### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           mkdir windows
-          cp dist/PySN windows
+          cp -r dist/* windows
           Compress-Archive -Path "windows/*" -DestinationPath PySN_Windows.zip
 
       - name: Upload Artifact (MacOS)
@@ -106,8 +106,7 @@ jobs:
           tag_name: v2.1.13
           release_name: v2.1.13
           body: |
-            Change Windows build directories and stop building Windows release as one file. This should stop false-positives from Windows Defender,
-            however the uncompressed files are a bit larger than the previous single executable.
+            Remove --onefile from Windows build. Still seems to build as one file and may stop being flagged as a false-positive by Windows Defender.
           draft: false
           prerelease: false
 


### PR DESCRIPTION
Corrects directories for windows build. Fixes issue with previous commits. Seems to build as one file without --onefile and appears to cooperate with Defender a bit better than it did with --onefile.