### PR TITLE
Move updates folder on MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,10 +176,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v2.6.2
-          name: v2.6.2
+          tag_name: v2.6.3
+          name: v2.6.3
           body: |
-            Try to fix icon on MacOS again.
+            Store updates in the correct place on MacOS.
+
+            These were getting shoved into the app's Contents/MacOS folder. Now they should be next to the app.
           draft: false
           prerelease: false
           files: |

--- a/PySN.py
+++ b/PySN.py
@@ -38,7 +38,10 @@ class ConfigSettings():
 
     def get_path():
         if getattr(sys, 'frozen', False):
-            app_path = os.path.dirname(sys.executable)
+            if sys.platform.startswith('darwin'):
+                app_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(sys.executable))))
+            else:
+                app_path = os.path.dirname(sys.executable)
         else:
             app_path = os.path.dirname(os.path.abspath(__file__))
         normalized_path = app_path.replace('\\','/')


### PR DESCRIPTION
This was getting shoved into the app's Contents/MacOS folder. Now it should be next to the app.